### PR TITLE
Fix syslog LoadError on Windows

### DIFF
--- a/spec/rzo_spec.rb
+++ b/spec/rzo_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Rzo do
         output_file = StringIO.new
         expect(app.generate).to receive(:write_file).with('Vagrantfile').and_yield(output_file)
         expect(app.generate).to receive(:timestamp).and_return('2017-08-18 13:00:09 -0700')
+        expect(Rzo).to receive(:version).and_return('0.1.0')
         app.run
         output_file.rewind
         output_file.read


### PR DESCRIPTION
Without this patch rizzo on Windows fails with

    C:/Ruby23-x64/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- syslog/logger (LoadError)
            from C:/Ruby23-x64/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
            from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rzo-0.2.0/lib/rzo/logging.rb:3:in `<top (required)>'

This patch addresses the problem by falling back to stream logging if the
syslog library fails to load.