### PR TITLE
Prioritize the present working control repository

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,12 @@ AllCops:
 Style/RedundantReturn:
   Enabled: false
 
+Style/InverseMethods:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Lint/UnneededDisable:
   Enabled: false
 

--- a/lib/rzo/option_parsing.rb
+++ b/lib/rzo/option_parsing.rb
@@ -59,7 +59,7 @@ module Rzo
           'STDOUT, STDERR {RZO_LOGTO}'
         opt :logto, log_msg, default: env['RZO_LOGTO'] || 'STDERR'
         opt :validate, 'Check the configuration for common issues {RZO_VALIDATE="false"}',
-            default: env['RZO_VALIDATE'] == 'false' ? false : true
+            default: !(env['RZO_VALIDATE'] == 'false')
         opt :syslog, 'Log to syslog', default: false, conflicts: :logto
         opt :verbose, 'Set log level to INFO {RZO_VERBOSE="true"}',
             default: env['RZO_VERBOSE'] == 'true'
@@ -119,7 +119,7 @@ module Rzo
     NAME = File.basename($PROGRAM_NAME).freeze
 
     # rubocop:disable Layout/IndentHeredoc
-    BANNER = <<-"EOBANNER".freeze
+    BANNER = <<-BANNERMSG.freeze
 usage: #{NAME} [GLOBAL OPTIONS] SUBCOMMAND [ARGS]
 Sub Commands:
 
@@ -128,6 +128,6 @@ Sub Commands:
   roles        Output all roles defined in the combined config
 
 Global options: (Note, command line arguments supersede ENV vars in {}'s)
-    EOBANNER
+    BANNERMSG
   end
 end

--- a/rzo.gemspec
+++ b/rzo.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rzo/version'

--- a/spec/fixtures/config/opts.yaml
+++ b/spec/fixtures/config/opts.yaml
@@ -1,0 +1,11 @@
+---
+:logto: '/dev/null'
+:validate: false
+:syslog: false
+:verbose: false
+:debug: false
+:config: "~/.rizzo.json"
+:version: false
+:help: false
+:subcommand: config
+:output: STDOUT

--- a/spec/rzo/app/config_spec.rb
+++ b/spec/rzo/app/config_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe Rzo::App::Config do
+  # rubocop:disable Security/YAMLLoad
+  let(:opts) { YAML.load(fixture('config/opts.yaml')) }
+  # rubocop:enable Security/YAMLLoad
+  # The personal configuration file only.
+  let(:personal_config) { JSON.parse(fixture('_home_rizzo.json')) }
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+  let(:subcommand) { described_class.new(opts, stdout, stderr) }
+
+  before :each do
+    expect(subcommand).to receive(:load_rizzo_config).and_return(personal_config)
+  end
+
+  describe 'baseline behavior' do
+    it 'runs with 0 exit code' do
+      expect(subcommand.run).to eq(0)
+    end
+  end
+
+  describe 'precedence list of control repositories' do
+    subject 'control_repos' do
+      subcommand.run
+      subcommand.config['control_repos']
+    end
+
+    context 'with no .rizzo.json in the CWD' do
+      it 'uses the configured control_repos as is' do
+        control_repos = personal_config['control_repos'].dup
+        expect(subject).to eq(control_repos)
+      end
+      it 'is a unique list of control repos' do
+        expect(subject.uniq).to eq(subject)
+      end
+    end
+
+    context 'when .rizzo.json exists in the CWD' do
+      before :each do
+        expect(subcommand).to receive(:project_dir).with(Dir.pwd).and_return(Dir.pwd)
+      end
+      it 'places the CWD project first in the list' do
+        expect(subject.first).to eq(Dir.pwd)
+      end
+      it 'adds only one control repo' do
+        expected_size = 1 + personal_config['control_repos'].size
+        expect(subject.size).to eq(expected_size)
+      end
+      it 'is a unique list of control repos' do
+        expect(subject.uniq).to eq(subject)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Without this patch the control repository in the present working directory is
not used unless explicitly added to the personal configuration file.  This is a
problem because the personal configuration file should be the same across all
teams, and the infra team will be switching among teams quite a bit.

This patch addresses the problem by implementing the following behaviors.  If
the pwd is inside a control repository (denoted by the presence of
.rizzo.json), that control repository is added, or moved, to the top of the
control repo list.

The personal configuration at ~/.rizzo.json is not considered a project control
repository.